### PR TITLE
feat: improve error handling and messaging in EditorSection and parser

### DIFF
--- a/src/compiler/compiler.mjs
+++ b/src/compiler/compiler.mjs
@@ -1086,16 +1086,6 @@ function preCheck(parsedDSL) {
     });
 
     // Check for valid command types
-    // parsedDSL.cmds.forEach(cmd => {
-// <<<<<<< HEAD
-//         if (!["page", "show", "hide", "set", "set_multiple", "set_matrix", "set_matrix_multiple", "add", "insert", "remove", "remove_at", "comment", "add_matrix_row", "add_matrix_column", "remove_matrix_row", "remove_matrix_column", "add_matrix_border"].includes(cmd.type)) {
-//             throw new Error(`Unknown command type: ${cmd.type}`);
-// =======
-        // if (!["page", "show", "hide", "set", "set_multiple", "set_matrix", "set_matrix_multiple", "add", "insert", "remove", "remove_at", "comment"].includes(cmd.type)) {
-        //     throw new Error(`Unknown command\n\nType: ${cmd.type}`);
-// >>>>>>> 9e31aa3 (fix: Rewrite error messages to be max 40 characters wide.)
-    //     }
-    // });
     parsedDSL.cmds.forEach(cmd => {
         if (![
             "page", "show", "hide", "set", "set_multiple", "set_matrix", "set_matrix_multiple",
@@ -1120,11 +1110,4 @@ function postCheck(pages) {
     if (pages.length === 0) {
         throw new Error("No pages found\n\nPlease define at least one page\nwith components.");
     }
-
-    // For each page, check if it has at least one component
-    pages.forEach((page, index) => {
-        if (page.length === 0) {
-            throw new Error(`Page ${index + 1} empty\n\nPlease show a component using:\nshow <component_name>`);
-        }
-    });
 }

--- a/src/components/EditorSection.js
+++ b/src/components/EditorSection.js
@@ -114,22 +114,68 @@ const EditorSection = ({
           </Tooltip>
         </Box>
         <div style={{ flexGrow: 1, overflow: "auto" }}>
-          {// Use terminal-like font and don't wrap lines
-            error ? (
-              <div
-                style={{
-                  fontFamily: "monospace",
-                  color: "rgb(255, 118, 118)",
-                  fontSize: "14px",
-                  padding: "30px",
-                  whiteSpace: "pre",
-                }}
-              >
-                {error}
-              </div>
-            ) : (
-              <MermaidEditor value={compiledMerlin} onChange={() => {}} />
-            )}
+          {
+            error
+              ? error.startsWith("Compile error:\nNothing to show\n")
+                ? (
+                  <div
+                    style={{
+                      fontFamily: "inherit",
+                      color: "#999",
+                      fontSize: "15px",
+                      padding: "30px",
+                      whiteSpace: "pre-line",
+                    }}
+                  >
+                    Nothing to show yet. Please enter some code above.
+                    <br />
+                    <br />
+                    <b>Example input format:</b>
+                    <div
+                      style={{
+                        fontFamily: "monospace",
+                        fontSize: "14px",
+                        padding: "14px 18px",
+                        margin: "10px 0",
+                        background: "#23272f",
+                        color: "#e0e0e0",
+                        borderRadius: "7px",
+                        whiteSpace: "pre",
+                        overflowX: "auto",
+                      }}
+                    >
+                      &lt;type&gt; &lt;component_name&gt; {`{`} <br />
+                        &nbsp;&nbsp;... <br />
+                      {`}`} <br />
+                      <br />
+                      page <br />
+                      show &lt;component_name&gt;
+                    </div>
+                    <span style={{ fontSize: "13px" }}>
+                      • <b>&lt;type&gt;</b>: The type of component (e.g., <i>array</i>, <i>graph</i>, etc.)<br />
+                      • <b>&lt;component_name&gt;</b>: A name you choose for your component<br />
+                    </span>
+                    <br />
+                    For more information, please visit the documentation.
+                  </div>
+                )
+                : (
+                  <div
+                    style={{
+                      fontFamily: "monospace",
+                      color: "rgb(255, 118, 118)",
+                      fontSize: "14px",
+                      padding: "30px",
+                      whiteSpace: "pre",
+                    }}
+                  >
+                    {error}
+                  </div>
+                )
+              : (
+                <MermaidEditor value={compiledMerlin} onChange={() => {}} />
+              )
+          }
         </div>
       </Box>
     </div>

--- a/src/parser/merlinLite.ne
+++ b/src/parser/merlinLite.ne
@@ -141,7 +141,7 @@ const getDef = ([el]) => {
 # Pass your lexer object using the @lexer option:
 @lexer lexer
 
-root -> nlw:* one_per_line[definition] nlw:+ one_per_line[commands] nlw:* {% ([, defs, , cmds]) => ({ defs: defs.flat(), cmds: cmds.flat() }) %}
+root -> nlw:* one_per_line[definition]:? nlw:* one_per_line[commands] nlw:* {% ([, defs, , cmds]) => ({ defs: (defs ?? []).flat(), cmds: (cmds ?? []).flat() }) %}
 
 # - DEFINITIONS - #
 # List of all definitions

--- a/src/parser/parser.js
+++ b/src/parser/parser.js
@@ -48,7 +48,23 @@ var grammar = {
     ParserRules: [
     {"name": "root$ebnf$1", "symbols": []},
     {"name": "root$ebnf$1", "symbols": ["root$ebnf$1", "nlw"], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
-    {"name": "root$macrocall$2", "symbols": ["definition"]},
+    {"name": "root$ebnf$2$macrocall$2", "symbols": ["definition"]},
+    {"name": "root$ebnf$2$macrocall$1$ebnf$1", "symbols": []},
+    {"name": "root$ebnf$2$macrocall$1$ebnf$1$subexpression$1$ebnf$1", "symbols": ["nlw"]},
+    {"name": "root$ebnf$2$macrocall$1$ebnf$1$subexpression$1$ebnf$1", "symbols": ["root$ebnf$2$macrocall$1$ebnf$1$subexpression$1$ebnf$1", "nlw"], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
+    {"name": "root$ebnf$2$macrocall$1$ebnf$1$subexpression$1", "symbols": ["root$ebnf$2$macrocall$1$ebnf$1$subexpression$1$ebnf$1", "root$ebnf$2$macrocall$2"]},
+    {"name": "root$ebnf$2$macrocall$1$ebnf$1", "symbols": ["root$ebnf$2$macrocall$1$ebnf$1", "root$ebnf$2$macrocall$1$ebnf$1$subexpression$1"], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
+    {"name": "root$ebnf$2$macrocall$1", "symbols": ["root$ebnf$2$macrocall$2", "root$ebnf$2$macrocall$1$ebnf$1"], "postprocess":  ([first, rest]) => {
+            const firstValue = first[0];
+            const restValues = rest.map(([, value]) => value[0]);
+            // Include all items, even comments
+            return [firstValue, ...restValues];
+        } },
+    {"name": "root$ebnf$2", "symbols": ["root$ebnf$2$macrocall$1"], "postprocess": id},
+    {"name": "root$ebnf$2", "symbols": [], "postprocess": function(d) {return null;}},
+    {"name": "root$ebnf$3", "symbols": []},
+    {"name": "root$ebnf$3", "symbols": ["root$ebnf$3", "nlw"], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
+    {"name": "root$macrocall$2", "symbols": ["commands"]},
     {"name": "root$macrocall$1$ebnf$1", "symbols": []},
     {"name": "root$macrocall$1$ebnf$1$subexpression$1$ebnf$1", "symbols": ["nlw"]},
     {"name": "root$macrocall$1$ebnf$1$subexpression$1$ebnf$1", "symbols": ["root$macrocall$1$ebnf$1$subexpression$1$ebnf$1", "nlw"], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
@@ -60,23 +76,9 @@ var grammar = {
             // Include all items, even comments
             return [firstValue, ...restValues];
         } },
-    {"name": "root$ebnf$2", "symbols": ["nlw"]},
-    {"name": "root$ebnf$2", "symbols": ["root$ebnf$2", "nlw"], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
-    {"name": "root$macrocall$4", "symbols": ["commands"]},
-    {"name": "root$macrocall$3$ebnf$1", "symbols": []},
-    {"name": "root$macrocall$3$ebnf$1$subexpression$1$ebnf$1", "symbols": ["nlw"]},
-    {"name": "root$macrocall$3$ebnf$1$subexpression$1$ebnf$1", "symbols": ["root$macrocall$3$ebnf$1$subexpression$1$ebnf$1", "nlw"], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
-    {"name": "root$macrocall$3$ebnf$1$subexpression$1", "symbols": ["root$macrocall$3$ebnf$1$subexpression$1$ebnf$1", "root$macrocall$4"]},
-    {"name": "root$macrocall$3$ebnf$1", "symbols": ["root$macrocall$3$ebnf$1", "root$macrocall$3$ebnf$1$subexpression$1"], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
-    {"name": "root$macrocall$3", "symbols": ["root$macrocall$4", "root$macrocall$3$ebnf$1"], "postprocess":  ([first, rest]) => {
-            const firstValue = first[0];
-            const restValues = rest.map(([, value]) => value[0]);
-            // Include all items, even comments
-            return [firstValue, ...restValues];
-        } },
-    {"name": "root$ebnf$3", "symbols": []},
-    {"name": "root$ebnf$3", "symbols": ["root$ebnf$3", "nlw"], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
-    {"name": "root", "symbols": ["root$ebnf$1", "root$macrocall$1", "root$ebnf$2", "root$macrocall$3", "root$ebnf$3"], "postprocess": ([, defs, , cmds]) => ({ defs: defs.flat(), cmds: cmds.flat() })},
+    {"name": "root$ebnf$4", "symbols": []},
+    {"name": "root$ebnf$4", "symbols": ["root$ebnf$4", "nlw"], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
+    {"name": "root", "symbols": ["root$ebnf$1", "root$ebnf$2", "root$ebnf$3", "root$macrocall$1", "root$ebnf$4"], "postprocess": ([, defs, , cmds]) => ({ defs: (defs ?? []).flat(), cmds: (cmds ?? []).flat() })},
     {"name": "definition$subexpression$1", "symbols": ["comment"]},
     {"name": "definition$subexpression$1", "symbols": ["array_def"]},
     {"name": "definition$subexpression$1", "symbols": ["matrix_def"]},


### PR DESCRIPTION
Depends on [mermaid-merlin#3](https://github.com/ETH-PEACH-Lab/mermaid-merlin/pull/3) (merge first)

Fixes #21 allowing empty pages


Additionally, we now have a more friendly message when the editor is empty or nothing is being shown yet (before: red warning text, might be a bit intimidating for starters):

<img width="333" height="338.4" alt="Screenshot 2025-07-10 at 15 30 26" src="https://github.com/user-attachments/assets/7d916a94-85f9-485a-b679-ca7287452df0" />
