### PR TITLE
fix: QuickTime not opening

### DIFF
--- a/src/components/RendererSection.js
+++ b/src/components/RendererSection.js
@@ -227,14 +227,22 @@ const RendererSection = ({
                   </Button>
                 </ListItem>
                 <ListItem disableGutters sx={{ px: 1.5 }}>
-                  <Button fullWidth onClick={() => handleExport('gif')} startIcon={<GifBox />} sx={{ justifyContent: 'flex-start', textAlign: 'left', px: 2 }}>
-                    <ListItemText primary="GIF" />
-                  </Button>
+                    <Tooltip title={pages.length < 2 ? 'Requires at least 2 pages' : ''} disableHoverListener={pages.length >= 2} placement="top" PopperProps={{ modifiers: [{ name: 'offset', options: { offset: [0, -16] } }] }}>
+                      <span style={{ width: '100%' }}>
+                        <Button fullWidth onClick={() => handleExport('gif')} startIcon={<GifBox />} sx={{ justifyContent: 'flex-start', textAlign: 'left', px: 2 }} disabled={pages.length < 2}>
+                          <ListItemText primary="GIF" />
+                        </Button>
+                      </span>
+                    </Tooltip>
                 </ListItem>
                 <ListItem disableGutters sx={{ px: 1.5 }}>
-                  <Button fullWidth onClick={() => handleExport('video')} startIcon={<Movie />} sx={{ justifyContent: 'flex-start', textAlign: 'left', px: 2 }}>
-                    <ListItemText primary="Video (MP4)" />
-                  </Button>
+                    <Tooltip title={pages.length < 2 ? 'Requires at least 2 pages' : ''} disableHoverListener={pages.length >= 2} placement="top" PopperProps={{ modifiers: [{ name: 'offset', options: { offset: [0, -16] } }] }}>
+                      <span style={{ width: '100%' }}>
+                        <Button fullWidth onClick={() => handleExport('video')} startIcon={<Movie />} sx={{ justifyContent: 'flex-start', textAlign: 'left', px: 2 }} disabled={pages.length < 2}>
+                          <ListItemText primary="Video (MP4)" />
+                        </Button>
+                      </span>
+                    </Tooltip>
                 </ListItem>
                 <ListItem disableGutters sx={{ px: 1.5 }}>
                   <Button fullWidth onClick={onOpenCustomExport} startIcon={<SettingsIcon />} sx={{ justifyContent: 'flex-start', textAlign: 'left', px: 2 }}>


### PR DESCRIPTION
Fixes #40, no dependencies

Fixes:
- **QuickTime compatibility issue:** When exporting from Chrome, it will use codec VP9 which is not widely supported, e.g. for example QuickTime does not support it. Switched to H.264 export by default.
- Greyed out video and GIF option when having only one page (options don't make sense in this case). Before threw console error and no visual feedback.

On hover we get a tooltip:
<img width="540" height="442" alt="Screenshot 2025-07-20 at 22 15 41" src="https://github.com/user-attachments/assets/bec7edfa-ad6c-4e42-a644-f0ecb9202b28" />
