### PR TITLE
fix: Update newline matching in lexer to support both LF and CRLF

### DIFF
--- a/src/compiler/compiler.mjs
+++ b/src/compiler/compiler.mjs
@@ -2070,7 +2070,7 @@ export default function convertParsedDSLtoMermaid(parsedDSLOriginal) {
 function preCheck(parsedDSL) {
     if (!parsedDSL || !parsedDSL.defs || !parsedDSL.cmds || 
         (Array.isArray(parsedDSL.defs) && Array.isArray(parsedDSL.cmds) && 
-         parsedDSL.defs.length === 0 && parsedDSL.cmds.length === 0)) {
+         parsedDSL.defs.length !== 0 && parsedDSL.cmds.length === 0)) {
         throw new Error("Nothing to show\n\nPlease define an object and a page.\nThen show it using the 'show' command");
     }
 

--- a/src/components/languageConfig.js
+++ b/src/components/languageConfig.js
@@ -48,48 +48,55 @@ export const typeDocumentation = {
     description: 'Arrays represent ordered collections of elements with indexed access.',
     features: ['Fixed or dynamic size', 'Index-based element access', 'Support for colors and arrows'],
     url: 'https://eth-peach-lab.github.io/merlin-docs/docs/data-structures/array',
-    insertText: `array \${1:arr} = {\n    value: [\${2:1,2,3}]\n    color: [\${3:"red", null, "blue"}]\n    arrow: [\${4:null, "i", null}]\n}`,
+    insertText: `array \${1:arr} = {\n  value: [\${2:1,2,3}]\n  color: [\${3:"red", null, "blue"}]\n  arrow: [\${4:null, "i", null}]\n}`,
+    insertTextName: 'arr',
     supportedProperties: ['value', 'color', 'arrow', 'above', 'below', 'left', 'right']
   },
   matrix: {
     description: 'Matrices represent 2D grids of elements with row-column access.',
     features: ['2D grid structure', 'Row and column operations', 'Border support'],
     url: 'https://eth-peach-lab.github.io/merlin-docs/docs/data-structures/matrix',
-    insertText: `matrix \${1:grid} = {\n    value: [[\${2:1,2}],[\${3:3,4}]]\n    color: [[\${4:null, "red"}], [\${5:null, null}]]\n}`,
+    insertText: `matrix \${1:grid} = {\n  value: [[\${2:1,2}],[\${3:3,4}]]\n  color: [[\${4:null, "red"}], [\${5:null, null}]]\n}`,
+    insertTextName: 'grid',
     supportedProperties: ['value', 'color', 'arrow', 'above', 'below', 'left', 'right']
   },
   linkedlist: {
     description: 'Linked lists represent sequences of connected nodes.',
     features: ['Node-based structure', 'Dynamic size', 'Sequential access'],
     url: 'https://eth-peach-lab.github.io/merlin-docs/docs/data-structures/linkedlist',
-    insertText: `linkedlist \${1:ll} = {\n    nodes: [\${2:head, node1, tail}]\n    value: [\${3:1, 2, 3}]\n}`,
+    insertText: `linkedlist \${1:ll} = {\n  nodes: [\${2:head, node1, tail}]\n  value: [\${3:1, 2, 3}]\n}`,
+    insertTextName: 'll',
     supportedProperties: ['nodes', 'value', 'color', 'arrow', 'above', 'below', 'left', 'right']
   },
   stack: {
     description: 'Stacks implement Last-In-First-Out (LIFO) data structure.',
     features: ['LIFO operations', 'Push/pop semantics', 'Visual stack representation'],
     url: 'https://eth-peach-lab.github.io/merlin-docs/docs/data-structures/stack',
-    insertText: `stack \${1:s} = {\n    value: [\${2:"main", "func"}]\n    color: [\${3:null, "blue"}]\n}`,
+    insertText: `stack \${1:s} = {\n  value: [\${2:"main", "func"}]\n  color: [\${3:null, "blue"}]\n}`,
+    insertTextName: 's',
     supportedProperties: ['value', 'color', 'arrow', 'above', 'below', 'left', 'right']
   },
   tree: {
     description: 'Trees represent hierarchical data structures with parent-child relationships.',
     features: ['Hierarchical structure', 'Parent-child relationships', 'Subtree operations'],
     url: 'https://eth-peach-lab.github.io/merlin-docs/docs/data-structures/tree',
-    insertText: `tree \${1:t} = {\n    nodes: [\${2:n1, n2, n3}]\n    children: [\${3:n1-n2, n1-n3}]\n    value: [\${4:1,2,3}]\n}`,
+    insertText: `tree \${1:t} = {\n  nodes: [\${2:n1, n2, n3}]\n  children: [\${3:n1-n2, n1-n3}]\n  value: [\${4:1,2,3}]\n}`,
+    insertTextName: 't',
   },
   graph: {
     description: 'Graphs represent networks of interconnected nodes and edges.',
     features: ['Node and edge operations', 'Flexible connections', 'Visibility control'],
     url: 'https://eth-peach-lab.github.io/merlin-docs/docs/data-structures/graph',
-    insertText: `graph \${1:g} = {\n    nodes: [\${2:A,B,C}]\n    edges: [\${3:A-B, B-C}]\n    value: [\${4:1,2,3}]\n    color: [\${5:"red", null, "blue"}]\n}`,
+    insertText: `graph \${1:g} = {\n  nodes: [\${2:A,B,C}]\n  edges: [\${3:A-B, B-C}]\n  value: [\${4:1,2,3}]\n  color: [\${5:"red", null, "blue"}]\n}`,
+    insertTextName: 'g',
     supportedProperties: ['nodes', 'edges', 'value', 'color', 'arrow', 'hidden', 'above', 'below', 'left', 'right']
   },
   text: {
     description: 'Text elements for displaying formatted text content.',
     features: ['Multi-line support', 'Font customization', 'Alignment options'],
     url: 'https://eth-peach-lab.github.io/merlin-docs/docs/data-structures/text',
-    insertText: `text \${1:label} = {\n    value: \${2:"Hello, world!"}\n    fontSize: \${3:16}\n    color: \${4:"gray"}\n}`,
+    insertText: `text \${1:label} = {\n  value: \${2:"Hello, world!"}\n  fontSize: \${3:16}\n  color: \${4:"gray"}\n}`,
+    insertTextName: 'label',
     supportedProperties: ['value', 'fontSize', 'fontWeight', 'fontFamily', 'align', 'lineSpacing', 'width', 'height']
   }
 };

--- a/src/context/ParseCompileContext.js
+++ b/src/context/ParseCompileContext.js
@@ -40,7 +40,14 @@ export function ParseCompileProvider({ children, initialCode = "" }) {
         const codeLines = code.split('\n');
         const totalLines = codeLines.length;
         const validCurrentLine = Math.max(1, Math.min(currentLine, totalLines));
-        
+
+        // Check if all lines are empty or whitespaces, if so don't compile or parse (no error)
+        const allEmpty = codeLines.every(line => line.trim() === '');
+        if (allEmpty) {
+            setError(null);
+            return;
+        }
+
         // If skipCurrentLine is true, remove the current line from processing
         if (skipCurrentLine && validCurrentLine <= totalLines) {
             codeLines[validCurrentLine - 1] = ''; // Replace current line with empty string

--- a/src/context/ParseCompileContext.js
+++ b/src/context/ParseCompileContext.js
@@ -45,6 +45,11 @@ export function ParseCompileProvider({ children, initialCode = "" }) {
         const allEmpty = codeLines.every(line => line.trim() === '');
         if (allEmpty) {
             setError(null);
+
+            // Clear Merlin Renderer
+            setParsedCode(null);
+            setCompiledMerlin(null);
+            setPages([]);
             return;
         }
 

--- a/src/parser/merlinLite.ne
+++ b/src/parser/merlinLite.ne
@@ -99,7 +99,7 @@ trim[X] -> _ $X _ {% ([, value, ]) => id(value) %}
 const moo = require("moo");
 
 const lexer = moo.compile({
-  nlw: { match: /[ \t]*\n[ \t]*/, lineBreaks: true },
+  nlw: { match: /[ \t]*\r?\n[ \t]*/, lineBreaks: true },
   ws:     /[ \t]+/,
   nullT: { match: /null/, value: () => null },
   number: /-?(?:[0-9]*\.[0-9]+|[0-9]+)/,

--- a/src/parser/parser.js
+++ b/src/parser/parser.js
@@ -6,7 +6,7 @@ function id(x) { return x[0]; }
 const moo = require("moo");
 
 const lexer = moo.compile({
-  nlw: { match: /[ \t]*\n[ \t]*/, lineBreaks: true },
+  nlw: { match: /[ \t]*\r?\n[ \t]*/, lineBreaks: true },
   ws:     /[ \t]+/,
   nullT: { match: /null/, value: () => null },
   number: /-?(?:[0-9]*\.[0-9]+|[0-9]+)/,


### PR DESCRIPTION
Fix of #18

Apparently the parser was missing a definition to catch [carriage return](https://en.wikipedia.org/wiki/Carriage_return) characters which are generated on windows upon changing something in the editor, which caused a parse error.

Thanks to @azable to figuring this out!


Notes:
- Also addressed #60
- Also addressed the fact that autocomplete will also add `page` and `show <obj>` command if not already present as described as part of #58